### PR TITLE
sqlx instead of GORM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ proto:
 
 test:
 	go test -v ./...
+
+benchmark:
+	go test -bench=./... -benchmem -benchtime 10s

--- a/server/server.go
+++ b/server/server.go
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS accounts (
 	created_at timestamp without time zone NOT NULL DEFAULT (now() at time zone 'utc')
 );
 
-CREATE UNIQUE INDEX ON accounts ((lower(email)));
+CREATE UNIQUE INDEX IF NOT EXISTS accounts_email ON accounts ((lower(email)));
 `
 
 type Account struct {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"flag"
+	"strconv"
 	"testing"
 
 	"github.com/arbarlow/account_service/account"
@@ -45,6 +46,24 @@ func TestCreateSuccess(t *testing.T) {
 
 	assert.NotEmpty(t, account.Id)
 	assert.Nil(t, err)
+}
+
+func BenchmarkCreate(b *testing.B) {
+	truncate()
+
+	for i := 0; i < b.N; i++ {
+		ctx := context.Background()
+		req := &account.AccountCreateRequest{
+			Name:  "Alex B",
+			Email: "alexbarlowis@localhost" + strconv.Itoa(i),
+		}
+
+		_, err := as.Create(ctx, req)
+
+		if err != nil {
+			panic(err)
+		}
+	}
 }
 
 func TestCreateUniqueness(t *testing.T) {


### PR DESCRIPTION
I thought a full "ORM" was a bit heavy and since I don't use 90% of the features I did a simple re-write and added some benchmarks. Seems it's worth it, see below

sqlx
```
BenchmarkCreate-8          20000            827092 ns/op            2484 B/op         54 allocs/op
BenchmarkCreate-8          20000            803765 ns/op            2484 B/op         54 allocs/op
```

gorm
```
BenchmarkCreate-8           5000           2272560 ns/op           20454 B/op        310 allocs/op
BenchmarkCreate-8           5000           2367481 ns/op           20453 B/op        310 allocs/op
```

So a 4X speed improvement and I suppose the only lacking feature is the inability to update db columns on the fly. Perhaps some sort of simple migration framework would help here. I should investigate.